### PR TITLE
Resolves the request entity too large error

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -23,8 +23,8 @@ const Server = require('./Server');
 const app = express();
 const server = new Server()
 
-app.use(bodyParser.urlencoded({ extended: false }));
-app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({limit:'50mb', extended: true }));
+app.use(bodyParser.json({limit: '50mb'}));
 
 // Add CORS for DEVELOPMENT
 app.use(function(req, res, next) {


### PR DESCRIPTION
After a certain amount of items added, the Node gave the error PayloadTooLargeError: request entity too large (Payload Too Large indicates that the request entity is greater than the limits defined by the server);
After this error, it is no longer possible to add, delete or edit items;
The solution I found was to increase the limits to 50mb (default: 1mb):